### PR TITLE
added option to use em units for min and max font

### DIFF
--- a/flowtype.js
+++ b/flowtype.js
@@ -42,9 +42,6 @@
             var width = elw > settings.maximum ? settings.maximum : elw < settings.minimum ? settings.minimum : elw,
                fontBase = width / settings.fontRatio,
                fontSize = fontBase > settings.maxFont ? settings.maxFont : fontBase < settings.minFont ? settings.minFont : fontBase;
-            console.log('holler');
-            console.log('at');
-            console.log('your');
 
             $el.css({
                'font-size'   : fontSize + unit,


### PR DESCRIPTION
This allows for using 'ems' for minFont, maxFont, minimum, and maximum, via a useEm boolean.  fontRatio and lineRatio is essentially untouched.  

A dirty example of usage would be:

``` javascript
$('#em').flowtype({
    minimum: 31.25,
    maximum: 75,
    minFont: 0.75,
    maxFont: 2.5,
    useEm: true
});
```
