### PR TITLE
swap the call for the changes() method

### DIFF
--- a/flowtype.js
+++ b/flowtype.js
@@ -47,11 +47,12 @@
          
       // Context for resize callback
          var that = this;
-      // Make changes upon resize
-         $(window).resize(function(){changes(that);});
          
       // Set changes on load
          changes(this);
+         
+      // Make changes upon resize
+         $(window).resize(function(){changes(that);});
       });
    };
 }(jQuery));


### PR DESCRIPTION
this swap of lines is to make the call of the changes() a little bit more robust. Imagine a remote possibility of the window element being resized while the plugin is initialising, this will make a call of the changes() method because of the resize event (if this one happens after registering the listener) and another call of changes() that can't be omitted because it will always be called on initialise.
However making this modification the changes() method will be called first, but if the resized stops before registering the listener, the second call will not happen.
