### PR TITLE
adding package.json

### DIFF
--- a/flowtype.js
+++ b/flowtype.js
@@ -70,6 +70,7 @@
             fontBase = width / settings.fontRatio,
             fontSize = fontBase > settings.maxFont ? settings.maxFont : fontBase < settings.minFont ? settings.minFont : fontBase;
          $el.css('font-size', fontSize + 'px');
+         $el.triggerHandler('flowtype-finish');
       };
 
 // Make the magic visible

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "FlowType.JS",
+  "description": "Web typography at its finest: font-size and line-height based on element width.",
+  "version": "1.1.0",
+  "keywords": [
+    "responsive",
+    "typography",
+    "clever"
+  ],
+  "author": {
+    "name": "John Wilson",
+    "email": "john@j-wilson.com"
+  },
+  "contributors": [
+    {
+      "name": "Jean-cédric Thérond",
+      "email": "jean-cedric.therond@cellfishmedia.fr"
+    }
+  ],
+  "dependencies": {
+    "jquery": ""
+  },
+  "homepage": "http://simplefocus.com/flowtype",
+  "bugs": "https://github.com/simplefocus/FlowType.JS/issues",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/simplefocus/FlowType.JS.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://raw.githubusercontent.com/simplefocus/FlowType.JS/master/LICENSE.txt"
+    }
+  ],
+  "analyze": false,
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
       "url": "https://raw.githubusercontent.com/simplefocus/FlowType.JS/master/LICENSE.txt"
     }
   ],
-  "analyze": false,
   "engines": {
     "node": ">=0.10.0"
   }


### PR DESCRIPTION
Hi,

I wrote a small package.json to be able to add FlowType.JS as a npm dependency.
Now you can : 

    npm install --save kane-thornwyrd/FlowType.JS

Or just set your dependencies object as followed :

    dependencies": {
      "grunt": "^0.4.5",
      "grunt-contrib-jshint": "^0.10.0",
      "grunt-contrib-watch": "^0.6.1",
      "underscore": "^1.6.0",
      "FlowType.JS": "kane-thornwyrd/FlowType.JS"
     },

If you agree to merge this pull request you'll find handy to replace `kane-thornwyrd/FlowType.JS` by `simplefocus/FlowType.JS`.

Eventually you may do some tweak and a `npm publish`.