### PR TITLE
Debounced window resize for slower browsers

### DIFF
--- a/flowtype.js
+++ b/flowtype.js
@@ -40,7 +40,13 @@
       // Context for resize callback
          var that = this;
       // Make changes upon resize
-         $(window).resize(function(){changes(that);});
+         var to = undefined;
+         $(window).resize(function(){   
+        	 changes(that);
+        	 //debounce resizes for slow browser that can't keep up with layout
+        	 if (to) clearTimeout(to);
+        	 to = setTimeout(function() {changes(that)}, 200);
+         });
       // Set changes on load
          changes(this);
       });


### PR DESCRIPTION
Fixed a race situation between the window size calculation and the resize event in slow browsers by triggering an additional relayout 200ms after the last resize event